### PR TITLE
Update ResourceROITable.vue to remove Output Profit Column

### DIFF
--- a/src/features/resource_roi_overview/components/ResourceROITable.vue
+++ b/src/features/resource_roi_overview/components/ResourceROITable.vue
@@ -176,26 +176,6 @@
 				</template>
 			</XNDataTableColumn>
 			<XNDataTableColumn
-				key="outputProfit"
-				title="Output Profit"
-				sorter="default">
-				<template #title>
-					<div class="text-end">Output Profit</div>
-				</template>
-				<template #render-cell="{ rowData }">
-					<div
-						class="text-end"
-						:class="
-							rowData.outputProfit > 0
-								? 'text-positive'
-								: 'text-negative'
-						">
-						{{ formatNumber(rowData.outputProfit) }}
-						<span class="pl-1 font-light text-white/50"> $ </span>
-					</div>
-				</template>
-			</XNDataTableColumn>
-			<XNDataTableColumn
 				key="dailyProfit"
 				title="Daily Profit"
 				sorter="default">


### PR DESCRIPTION
I don't think output profit is useful on the Recipe ROI tool given the purpose of the tool is comparing apples to apples (daily profit, profit per area). Given the number of other columns, some trimming is justified, and frankly, new players may be confused by output profit. I would argue it is best removed.